### PR TITLE
catch all exceptions in the handler and send them to powerdns for dis…

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,12 @@ import io
 class MyHandler(pdns.remotebackend.Handler):
     def do_lookup(self,args):
         self.result =  []
+        self.log.append("Handling a new DNS request")
         if (args['qname'] == 'test.com' and args['qtype'] == 'ANY'):
-            self.result.append(self.record_prio_ttl('test.com','A','127.0.0.1',0,300))
+            self.result.append(self.record('test.com','A','127.0.0.1',ttl=300))
         if (args['qname'] == 'test.com' and (args['qtype'] == 'ANY' or args['qtype'] == 'SOA')):
-            self.result.append(self.record_prio_ttl('test.com','A','127.0.0.1',0,300))
-            self.result.append(self.record_prio_ttl('test.com','SOA','sns.dns.icann.org. noc.dns.icann.org. 2013073082 7200 3600 1209600 3600',0,300))
+            self.result.append(self.record('test.com','A','127.0.0.1',ttl=300))
+            self.result.append(self.record('test.com','SOA','sns.dns.icann.org. noc.dns.icann.org. 2013073082 7200 3600 1209600 3600',ttl=300))
 
 if __name__ == '__main__':
 	pdns.remotebackend.PipeConnector(MyHandler).run()
@@ -46,6 +47,8 @@ Details
 ---
 The Handler class will call your class with do\_\<api function\>. initialize becomes do\_initialize. The function is passed a hash with all the keys provided. 
 Please see http://doc.powerdns.com/html/remotebackend.html for details on the API. 
+
+All log messages will appear in the PowerDNS log. For the messages to appear, the PowerDNS log level needs to be set to 6 or above.
 
 Connector constructor is 
 ```

--- a/src/pdns/remotebackend/__init__.py
+++ b/src/pdns/remotebackend/__init__.py
@@ -2,6 +2,7 @@
 import json
 import re
 import sys
+import traceback
 
 VERSION = "0.7"
 """Module version string"""
@@ -177,7 +178,11 @@ class Connector:
                 writer.write(json.dumps({'result': h.result, 'log': h.log}))
             except ValueError:
                 writer.write(json.dumps({'result': False,
-                                         'log': "Cannot parse input"}))
+                                         'log': [ "Cannot parse input" ]}))
+            except:
+                writer.write(json.dumps({'result': False,
+                                         'log': [ traceback.format_exc() ]}))
+
             writer.write("\n")
             writer.flush()
 

--- a/src/pdns/remotebackend/__init__.py
+++ b/src/pdns/remotebackend/__init__.py
@@ -178,10 +178,11 @@ class Connector:
                 writer.write(json.dumps({'result': h.result, 'log': h.log}))
             except ValueError:
                 writer.write(json.dumps({'result': False,
-                                         'log': [ "Cannot parse input" ]}))
-            except:
+                                         'log': ["Cannot parse input"]}))
+            # errors are never visible if we don't catch this exception. 
+            except BaseException:
                 writer.write(json.dumps({'result': False,
-                                         'log': [ traceback.format_exc() ]}))
+                                         'log': [traceback.format_exc()]}))
 
             writer.write("\n")
             writer.flush()


### PR DESCRIPTION
This fixes one bug in the current code and one annoyance, as well as updating documentation. My version of PowerDNS (v4.0.0-alpha3, on ubuntu 16.04) requires that the log message is in a list, even if it's a single log message. So this wraps the single log message for the ValueError exception in a JSON list.

The new feature is that it captures all exceptions and send them back to PowerDNS as a log message. This current behavior in case of an exception in the custom handler code writes a message "Exception caught when receiving: Child closed pipe" and there's no way to get the exception that the code threw.

The doc change just updates the documentation to remove a call to a method that no longer exists and adds a logging example.