### PR TITLE
fixed UnixConnector for py3, fixed calling Handler constructor twice,…

### DIFF
--- a/src/pipe_abi.py
+++ b/src/pipe_abi.py
@@ -19,4 +19,10 @@ class MyHandler(pdns.remotebackend.Handler):
                             ttl=300))
 
 
-pdns.remotebackend.PipeConnector(MyHandler, {"abi": sys.argv[1]}).run()
+if __name__ == '__main__':
+    options = {"abi": sys.argv[1]}
+    if len(sys.argv) > 2:
+        options['path'] = sys.argv[2]
+        pdns.remotebackend.unix.UnixConnector(MyHandler, options).run()
+    else:
+        pdns.remotebackend.PipeConnector(MyHandler, options).run()


### PR DESCRIPTION
Hi,

Thanks for the excellent python module! 
I decided to use it for the RIPE Atlas dyndns project and came up with some fixes/improvements:

- fixed UnixConnector.
- fixed calling Handler constructor twice (mainloop, mainloop3)
- options are passed to the Handler
- context manager for Handler to have better control over freeing resources (db connections/files)
- description and version are overridable.
- implemented test for unix connector
- works on py2 and py3